### PR TITLE
Drop user account.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,8 @@ This service broker allows Cloud Foundry users to provision and deprovision depl
     $ uaac client add deployer-account-broker \
         --name deployer-account-broker \
         --authorized_grant_types client_credentials \
-        --authorities scim.write,uaa.admin \
+        --authorities scim.write,uaa.admin,cloud_controller.admin \
         --scope uaa.none
-    ```
-
-* Create CF user:
-
-    ```bash
-    $ uaac user add deployer-account-broker
-    $ uaac member add cloud_controller.admin deployer-account-broker
     ```
 
 * Update Concourse pipeline:

--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -8,10 +8,6 @@ uaa-address-staging:
 uaa-client-id-staging:
 uaa-client-secret-staging:
 uaa-zone-staging:
-cf-auth-address-staging:
-cf-token-address-staging:
-cf-username-staging:
-cf-password-staging:
 broker-username-staging:
 broker-password-staging:
 email-address-staging:
@@ -34,10 +30,6 @@ uaa-address-production:
 uaa-client-id-production:
 uaa-client-secret-production:
 uaa-zone-production:
-cf-auth-address-production:
-cf-token-address-production:
-cf-username-production:
-cf-password-production:
 broker-username-production:
 broker-password-production:
 email-address-production:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -26,10 +26,6 @@ jobs:
         UAA_CLIENT_SECRET: {{uaa-client-secret-staging}}
         UAA_ZONE: {{uaa-zone-staging}}
         CF_ADDRESS: {{cf-api-url-staging}}
-        CF_AUTH_ADDRESS: {{cf-auth-address-staging}}
-        CF_TOKEN_ADDRESS: {{cf-token-address-staging}}
-        CF_USERNAME: {{cf-username-staging}}
-        CF_PASSWORD: {{cf-password-staging}}
         BROKER_USERNAME: {{broker-username-staging}}
         BROKER_PASSWORD: {{broker-password-staging}}
         EMAIL_ADDRESS: {{email-address-staging}}
@@ -104,10 +100,6 @@ jobs:
         UAA_CLIENT_SECRET: {{uaa-client-secret-production}}
         UAA_ZONE: {{uaa-zone-production}}
         CF_ADDRESS: {{cf-api-url-production}}
-        CF_AUTH_ADDRESS: {{cf-auth-address-production}}
-        CF_TOKEN_ADDRESS: {{cf-token-address-production}}
-        CF_USERNAME: {{cf-username-production}}
-        CF_PASSWORD: {{cf-password-production}}
         BROKER_USERNAME: {{broker-username-production}}
         BROKER_PASSWORD: {{broker-password-production}}
         EMAIL_ADDRESS: {{email-address-production}}


### PR DESCRIPTION
Because there's no need for both a client and a user--I had just borrowed code from other libraries earlier and didn't realize I could use the same oauth client for both apis.