### PR TITLE
Update Fugacious references

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This service broker allows Cloud Foundry users to provision and deprovision depl
     Service instance: my-deployer-account
     Service: deployer-account
     ...
-    Dashboard: https://fugacio.us/m/k3MtzJWVZaNlnjBYJ7FUdpW2ZkDvhmQz
+    Dashboard: https://fugacious.18f.gov/m/k3MtzJWVZaNlnjBYJ7FUdpW2ZkDvhmQz
     ```
 
 * Retrieve credentials from dashboard link.

--- a/broker_test.go
+++ b/broker_test.go
@@ -76,7 +76,7 @@ var _ = Describe("broker", func() {
 	BeforeEach(func() {
 		uaaClient = FakeUAAClient{userGUID: "user-guid"}
 		cfClient = FakeCFClient{}
-		credentialSender = FakeCredentialSender{link: "https://fugacio.us/m/42"}
+		credentialSender = FakeCredentialSender{link: "https://fugacious.18f.gov/m/42"}
 		broker = DeployerAccountBroker{
 			uaaClient:        &uaaClient,
 			cfClient:         &cfClient,
@@ -118,7 +118,7 @@ var _ = Describe("broker", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(spec.IsAsync).To(Equal(false))
-			Expect(spec.DashboardURL).To(Equal("https://fugacio.us/m/42"))
+			Expect(spec.DashboardURL).To(Equal("https://fugacious.18f.gov/m/42"))
 
 			credentialSender.AssertExpectations(GinkgoT())
 			uaaClient.AssertExpectations(GinkgoT())

--- a/fugacious_test.go
+++ b/fugacious_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Fugacious", func() {
 
 	BeforeEach(func() {
 		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Location", "https://fugacio.us/m/42")
+			w.Header().Set("Location", "https://fugacious.18f.gov/m/42")
 			w.WriteHeader(header)
 		}))
 		sender = FugaciousCredentialSender{
@@ -35,7 +35,7 @@ var _ = Describe("Fugacious", func() {
 		It("retrieves a link from the fugacious server", func() {
 			url, err := sender.Send("testing")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(url).To(Equal("https://fugacio.us/m/42"))
+			Expect(url).To(Equal("https://fugacious.18f.gov/m/42"))
 		})
 	})
 


### PR DESCRIPTION
Fixing references by changing `https://fugacio.us/` to `https://fugacious.18f.gov/`

This accompanies https://github.com/18F/cg-site/pull/622, which updates this in the cloud.gov docs to match.